### PR TITLE
cert: fix ecdsa response issue

### DIFF
--- a/apis/v1/oas_json_gen.go
+++ b/apis/v1/oas_json_gen.go
@@ -2920,7 +2920,13 @@ func (s *CertificateDetails) Decode(d *jx.Decoder) error {
 		}
 		return nil
 	}); err != nil {
-		return errors.Wrap(err, "decode CertificateDetails")
+		// ecdsaを指定していない場合には{}が返ってくるはずだが、現状APIの裏側で変換する処理が入ってしまい[]が返ってくるので、
+		// 修正されるまでそれを無視する
+		if errArr := d.Arr(func(d *jx.Decoder) error { return nil }); errArr == nil {
+			return nil
+		} else {
+			return errors.Wrap(err, "decode CertificateDetails")
+		}
 	}
 
 	return nil


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

OpenAPI定義v2.0.x対応の時にecdsaフィールド向け修正が消えていたので再度ad-hocな対応を入れる。

### ドキュメントの変更は必要ですか？

必要無し