### PR TITLE
Use SAKURA prefix for envvar

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,7 +78,7 @@ jobs:
         run: |
           make test
         env:
-          SAKURACLOUD_TEST_HOST: ${{secrets.TEST_HOST}}
-          SAKURACLOUD_TEST_DOMAIN: ${{secrets.TEST_DOMAIN}}
-          SAKURACLOUD_ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
-          SAKURACLOUD_ACCESS_TOKEN_SECRET: ${{secrets.ACCESS_TOKEN_SECRET}}
+          SAKURA_TEST_HOST: ${{secrets.TEST_HOST}}
+          SAKURA_TEST_DOMAIN: ${{secrets.TEST_DOMAIN}}
+          SAKURA_ACCESS_TOKEN: ${{secrets.ACCESS_TOKEN}}
+          SAKURA_ACCESS_TOKEN_SECRET: ${{secrets.ACCESS_TOKEN_SECRET}}

--- a/certificates_test.go
+++ b/certificates_test.go
@@ -27,7 +27,7 @@ import (
 )
 
 func TestCertificateAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN", "SAKURACLOUD_ACCESS_TOKEN_SECRET")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN", "SAKURA_ACCESS_TOKEN_SECRET")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)

--- a/domains_test.go
+++ b/domains_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func TestDomainAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN",
-		"SAKURACLOUD_ACCESS_TOKEN_SECRET", "SAKURACLOUD_TEST_DOMAIN")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN",
+		"SAKURA_ACCESS_TOKEN_SECRET", "SAKURA_TEST_DOMAIN")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)
@@ -36,7 +36,7 @@ func TestDomainAPI(t *testing.T) {
 	ctx := context.Background()
 	domainOp := apigw.NewDomainOp(client)
 
-	domain, err := domainOp.Create(ctx, &v1.Domain{DomainName: os.Getenv("SAKURACLOUD_TEST_DOMAIN")})
+	domain, err := domainOp.Create(ctx, &v1.Domain{DomainName: os.Getenv("SAKURA_TEST_DOMAIN")})
 	require.Nil(t, err)
 
 	// TODO: 証明書を作ってのテストも行うようにする

--- a/groups_test.go
+++ b/groups_test.go
@@ -26,7 +26,7 @@ import (
 )
 
 func TestGroupAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN", "SAKURACLOUD_ACCESS_TOKEN_SECRET")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN", "SAKURA_ACCESS_TOKEN_SECRET")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)

--- a/routes_test.go
+++ b/routes_test.go
@@ -14,8 +14,8 @@ import (
 )
 
 func TestRouteAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN",
-		"SAKURACLOUD_ACCESS_TOKEN_SECRET", "SAKURACLOUD_TEST_HOST")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN",
+		"SAKURA_ACCESS_TOKEN_SECRET", "SAKURA_TEST_HOST")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)
@@ -28,7 +28,7 @@ func TestRouteAPI(t *testing.T) {
 
 	service, err := serviceOp.Create(ctx, &v1.ServiceDetailRequest{
 		Name:         "test-service",
-		Host:         os.Getenv("SAKURACLOUD_TEST_HOST"),
+		Host:         os.Getenv("SAKURA_TEST_HOST"),
 		Port:         v1.NewOptInt(80),
 		Protocol:     "http",
 		Subscription: subReq,
@@ -65,8 +65,8 @@ func TestRouteAPI(t *testing.T) {
 }
 
 func TestRouteExtraAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN",
-		"SAKURACLOUD_ACCESS_TOKEN_SECRET", "SAKURACLOUD_TEST_HOST")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN",
+		"SAKURA_ACCESS_TOKEN_SECRET", "SAKURA_TEST_HOST")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)
@@ -78,7 +78,7 @@ func TestRouteExtraAPI(t *testing.T) {
 	serviceOp := apigw.NewServiceOp(client)
 	service, err := serviceOp.Create(ctx, &v1.ServiceDetailRequest{
 		Name:         "test-service",
-		Host:         os.Getenv("SAKURACLOUD_TEST_HOST"),
+		Host:         os.Getenv("SAKURA_TEST_HOST"),
 		Port:         v1.NewOptInt(80),
 		Protocol:     "http",
 		Subscription: subReq,

--- a/services_test.go
+++ b/services_test.go
@@ -27,8 +27,8 @@ import (
 )
 
 func TestServiceAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN",
-		"SAKURACLOUD_ACCESS_TOKEN_SECRET", "SAKURACLOUD_TEST_HOST")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN",
+		"SAKURA_ACCESS_TOKEN_SECRET", "SAKURA_TEST_HOST")(t)
 
 	client, err := apigw.NewClient()
 	require.NoError(t, err)
@@ -42,7 +42,7 @@ func TestServiceAPI(t *testing.T) {
 	// Create a service for testing
 	serviceReq := v1.ServiceDetailRequest{
 		Name:         "test-service",
-		Host:         os.Getenv("SAKURACLOUD_TEST_HOST"),
+		Host:         os.Getenv("SAKURA_TEST_HOST"),
 		Port:         v1.NewOptInt(80),
 		Protocol:     "http",
 		Subscription: subReq,
@@ -53,7 +53,7 @@ func TestServiceAPI(t *testing.T) {
 
 	serviceUpd := v1.ServiceDetail{
 		Name:     "test-service-updated",
-		Host:     os.Getenv("SAKURACLOUD_TEST_HOST"),
+		Host:     os.Getenv("SAKURA_TEST_HOST"),
 		Port:     v1.NewOptInt(80),
 		Protocol: "http",
 	}

--- a/subscriptions_test.go
+++ b/subscriptions_test.go
@@ -46,7 +46,7 @@ func getSvcSubRequest() (v1.ServiceSubscriptionRequest, error) {
 }
 
 func TestSubscriptionAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN", "SAKURACLOUD_ACCESS_TOKEN_SECRET")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN", "SAKURA_ACCESS_TOKEN_SECRET")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)
@@ -61,7 +61,7 @@ func TestSubscriptionAPI(t *testing.T) {
 	require.Nil(t, err)
 	require.Greater(t, len(plans), 0)
 
-	if os.Getenv("ENABLE_APIGW_SUBSCRIPTION_TEST") != "1" {
+	if os.Getenv("ENABLE_SAKURA_APIGW_SUBSCRIPTION_TEST") != "1" {
 		return
 	}
 

--- a/users_test.go
+++ b/users_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestUserAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN", "SAKURACLOUD_ACCESS_TOKEN_SECRET")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN", "SAKURA_ACCESS_TOKEN_SECRET")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)
@@ -48,7 +48,7 @@ func TestUserAPI(t *testing.T) {
 }
 
 func TestUserExtraAPI(t *testing.T) {
-	testutil.PreCheckEnvsFunc("SAKURACLOUD_ACCESS_TOKEN", "SAKURACLOUD_ACCESS_TOKEN_SECRET")(t)
+	testutil.PreCheckEnvsFunc("SAKURA_ACCESS_TOKEN", "SAKURA_ACCESS_TOKEN_SECRET")(t)
 
 	client, err := apigw.NewClient()
 	require.Nil(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to Sakura Internet OSS!
We follow DCO and your commits need to contain `Signed-off-by` line: https://github.com/apps/dco
-->

### どのIssueを閉じますか？

No issue

### このPRはどういう変更を行いますか？

環境変数でSAKURAプレフィックスを利用するように変更。

### ドキュメントの変更は必要ですか？

必要なし